### PR TITLE
Migration to Python 3.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+serial2tcp-gateway/configuration.json
+__pycache__
+.vscode
+*.pyc

--- a/install.sh
+++ b/install.sh
@@ -33,7 +33,7 @@ read -p "Do you want to continue? (y/N)? " choice
 ## Installing the required programs
 echo -e '\nInstalling the required programs...'
 apt-get update >/dev/null
-apt-get --assume-yes install git python python-dev python-pip jq socat >/dev/null
+apt-get --assume-yes install git python3 python3-dev python3-pip jq socat >/dev/null
 
 
 ## Cloning the github repository
@@ -51,7 +51,7 @@ fi
 
 ## Installing the required python libraries
 echo -e '\nInstalling the required python libraries...'
-pip install -r requirements.txt > /dev/null
+pip3 install -r requirements.txt > /dev/null
 
 
 ## Creating the <serial2tcp-gateway> username

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-enum34
 pyudev
 pyserial
 zeroconf==0.19.1

--- a/serial2tcp-gateway/main.py
+++ b/serial2tcp-gateway/main.py
@@ -10,7 +10,7 @@ from socat2tcp import Socat2TCP
 from mdns_advertiser import MDNSAdvertiser
 from device_definitions import devices as registered_devices
 
-logging.basicConfig(filename="/var/log/serial2tcp-gateway/serial2tcp-gateway.log", format='%(asctime)s %(levelname)-8s - %(message)s', level=logging.INFO)
+logging.basicConfig(format='%(asctime)s %(levelname)-8s - %(message)s', level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 threads = {}

--- a/serial2tcp-gateway/main.py
+++ b/serial2tcp-gateway/main.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import pyudev
 import signal
@@ -55,7 +55,7 @@ def load_configuration(config_file=None):
 
 
 def signal_handler(signal, frame):
-    for device in threads.itervalues():
+    for device in threads.values():
         for thread in device:
             thread.stop()
     logger.info("Serial2TCP gateway program stopped")

--- a/systemd/serial2tcp-gateway.service
+++ b/systemd/serial2tcp-gateway.service
@@ -9,7 +9,7 @@ User=serial2tcp-gateway
 Restart=always
 RestartSec=5
 
-ExecStart=/usr/bin/python /opt/serial2tcp-gateway/main.py
+ExecStart=/opt/serial2tcp-gateway/main.py
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Developed against the current major version of Python 3 shipped with Raspbian.

Install Script and main.py tested on common apt-based distributions:
- Debian 9.4 Docker Image
- Raspbian 8.0 on Raspberry Pi 2 (armv7l)
- Ubuntu 16.04.3 LTS

This was actually pretty easy. The code already was so clean and well-laid out so that there only was one tiny change in the `main.py`.

Closes #2 